### PR TITLE
Update sync-controller.js

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -122,10 +122,9 @@ export const mimeTypesForPlaylist_ = function(master, media) {
   // An initialization segment means the media playlists is an iframe
   // playlist or is using the mp4 container. We don't currently
   // support iframe playlists, so assume this is signalling mp4
-  // fragments.
-  // the existence check for segments can be removed once
-  // https://github.com/videojs/m3u8-parser/issues/8 is closed
-  if (media.segments && media.segments.length && media.segments[0].map) {
+  // fragments if the uri doesn't end in .ts (which indicates mpeg2ts 
+  // segments).
+  if (media.segments.length && media.segments[0].map && !media.segments[0].uri.endsWith('.ts')) {
     container = 'mp4';
   }
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1011,8 +1011,9 @@ export default class SegmentLoader extends videojs.EventTarget {
     }
 
     // if the media initialization segment is changing, append it
-    // before the content segment
-    if (segment.map) {
+    // before the content segment.  only append to media source buffer
+    // if the segment is part of a fragmented mp4
+    if (segment.map && !segment.uri.endsWith('.ts')) {
       let initId = initSegmentId(segment.map);
 
       if (!this.activeInitSegmentId_ ||

--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -217,7 +217,8 @@ export default class SyncController extends videojs.EventTarget {
     let segment = segmentInfo.segment;
     let timingInfo;
 
-    if (segment.map) {
+    // Assume fragmented mp4 if map exists and segment uri doesn't end in .ts
+    if (segment.map && !segment.uri.endsWith('.ts')) {
       timingInfo = this.probeMp4Segment_(segmentInfo);
     } else {
       timingInfo = this.probeTsSegment_(segmentInfo);


### PR DESCRIPTION
Small fix to the assumption of fragmented mp4 when the EXT-X-MAP is being used.

## Description
https://github.com/videojs/videojs-contrib-hls/issues/991

## Specific Changes proposed
Adds a conditional check when segment.map is queried.
